### PR TITLE
MixedDofHandler checks (#320)

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -131,7 +131,7 @@ function _check_same_celltype(grid::AbstractGrid, cellset::AbstractVector{Int})
     celltype = typeof(grid.cells[first(cellset)])
     for cellid in cellset
         if celltype != typeof(grid.cells[cellid])
-            error("You are trying to use a CellIterator to loop over a cellset with different celltypes.")
+            error("The cells in your cellset are not all of the same celltype.")
         end
     end
 end


### PR DESCRIPTION
* change error message of _check_same_celltype 

It is more general, such that it can be used for different purposes and 
not just for the CellIterator.

* add checks when pushing FieldHandler to MixedDofHandler

Checks if all cells in FieldHandler have the same celltype and if the 
RefShape of the interpolations is the same as the RefShape of the cell 
we're trying to push the interpolations on.

* fix tests of MixedDofHandler

fix/remove all tests that made no sense (like pushing a 
RefCube-interpolation on a triangular cell).

* MixedDofHandler: test if errors are thrown for illegal FieldHandler